### PR TITLE
Fix missing indentation that made the docs skip the syntax highlighting

### DIFF
--- a/lib/live_motion/js.ex
+++ b/lib/live_motion/js.ex
@@ -46,27 +46,28 @@ defmodule LiveMotion.JS do
 
   ## Example
 
-    def popcorn(assigns) do
-      ~H"""
-      <div>
-        <div id="popcorn" style="font-size: 64px">
-          <span>🍿</span>
-        </div>
+      def popcorn(assigns) do
+        ~H"""
+        <div>
+          <div id="popcorn" style="font-size: 64px">
+            <span>🍿</span>
+          </div>
 
-        <button
-          type="button"
-          phx-click={
-            LiveMotion.JS.animate(
-              [rotate: [0, 20, -10, 30, -10, 0]],
-              [duration: 0.5],
-              to: "#popcorn"
-            )
-          }
-        >
-          Shake it!
-        </button>
-      </div>
-      """
+          <button
+            type="button"
+            phx-click={
+              LiveMotion.JS.animate(
+                [rotate: [0, 20, -10, 30, -10, 0]],
+                [duration: 0.5],
+                to: "#popcorn"
+              )
+            }
+          >
+            Shake it!
+          </button>
+        </div>
+        """
+      end
 
   ## Options
 
@@ -84,30 +85,31 @@ defmodule LiveMotion.JS do
 
   ## Example
 
-    def popcorn(assigns) do
-      ~H"""
-      <div>
-        <div id="popcorn" style="font-size: 64px">
-          <span>🍿</span>
-        </div>
+      def popcorn(assigns) do
+        ~H"""
+        <div>
+          <div id="popcorn" style="font-size: 64px">
+            <span>🍿</span>
+          </div>
 
-        <button
-          type="button"
-          phx-click={
-            LiveMotion.JS.toggle(
-              [
-                in: [x: -200],
-                out: [x: 200]
-              ],
-              [],
-              to: "#popcorn"
-            )
-          }
-        >
-          Move popcorn
-        </button>
-      </div>
-      """
+          <button
+            type="button"
+            phx-click={
+              LiveMotion.JS.toggle(
+                [
+                  in: [x: -200],
+                  out: [x: 200]
+                ],
+                [],
+                to: "#popcorn"
+              )
+            }
+          >
+            Move popcorn
+          </button>
+        </div>
+        """
+      end
 
   ## Options
 


### PR DESCRIPTION
The code examples in the JS section does not have syntax highlighting due to missing indentation.

It looks like this right now:
<img width="583" alt="image" src="https://user-images.githubusercontent.com/1052/162994715-7b557cb5-bfa1-4569-a512-d1bab3378ae0.png">
(note the missing syntax highlighting of the function header)

and with this PR it looks like this instead

<img width="534" alt="image" src="https://user-images.githubusercontent.com/1052/162994883-6ea9d0ec-fc88-4def-9edf-f37d45ad882e.png">
